### PR TITLE
adds validate command to cli

### DIFF
--- a/cda2fhir/cli.py
+++ b/cda2fhir/cli.py
@@ -1,3 +1,7 @@
+import sys
+
+from gen3_tracker.common import ERROR_COLOR, INFO_COLOR
+
 from cda2fhir import cda2fhir
 import click
 import os
@@ -31,6 +35,32 @@ def transform(n_samples, n_diagnosis, save, verbose, path):
             raise ValueError(f"Path: '{path}' is not a valid directory.")
 
     cda2fhir.cda2fhir(path, n_samples, n_diagnosis, save, verbose)
+
+
+@cli.command('validate')
+@click.option("-d", "--debug", is_flag=True, default=False,
+              help="Run in debug mode.")
+@click.option("-p", "--path", default=None,
+              help="Path to read the FHIR NDJSON files. default is CDA2FHIR/data/META.")
+def validate(debug: bool, path):
+    """Validate the output FHIR ndjson files."""
+    from gen3_tracker.git import run_command
+
+    if not path:
+        path = str(Path(importlib.resources.files('cda2fhir').parent / 'data' / 'META'))
+    if not os.path.isdir(path):
+        raise ValueError(f"Path: '{path}' is not a valid directory.")
+
+    try:
+        from gen3_tracker.meta.validator import validate as validate_dir
+        from halo import Halo
+        with Halo(text='Validating', spinner='line', placement='right', color='white'):
+            result = validate_dir(path)
+        click.secho(result.resources, fg=INFO_COLOR, file=sys.stderr)
+    except Exception as e:
+        click.secho(str(e), fg=ERROR_COLOR, file=sys.stderr)
+        if debug:
+            raise
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'pandas',
         'inflection',
         'iteration_utilities',
-        'gen3-tracker>=0.0.4rc36',
+        'gen3-tracker>=0.0.7rc1',
         'fhir.resources>=7.1.0',  # FHIR® (Release R5, version 5.0.0)
         'sqlalchemy>=2.0.31'
 


### PR DESCRIPTION
This PR adds validate command.

To test:
### disable gen3-client
```
mv ~/.gen3/gen3_client_config.ini ~/.gen3/gen3_client_config.ini-xxx
mv ~/.gen3/gen3-client ~/.gen3/gen3-client-xxx
```

### Run validate
```
 time cda2fhir validate
{'summary': {'Specimen': 721837, 'Observation': 731005, 'ResearchStudy': 423, 'BodyStructure': 163, 'Condition': 95262, 'ResearchSubject': 160649, 'Patient': 138738}}

real    5m13.700s
user    5m0.894s
sys     0m5.738s

```

### Restore gen3-client

```
mv ~/.gen3/gen3-client-xxx ~/.gen3/gen3-client
mv ~/.gen3/gen3_client_config.ini-xxx ~/.gen3/gen3_client_config.ini
  
```
